### PR TITLE
Update package-sissvoc-vanilla.sh

### DIFF
--- a/package-sissvoc-vanilla.sh
+++ b/package-sissvoc-vanilla.sh
@@ -20,7 +20,8 @@ cd ..
 curl -L -O https://github.com/jyucsiro/sissvoc/archive/sissvoc-vanilla-v0.2.zip
 unzip sissvoc-vanilla-v0.2.zip
 mv sissvoc-sissvoc-vanilla-v0.2 sissvoc
-cd sissvoc
-cd ..
-bash -c package-sissvoc-vanilla--no-build.sh
+# remove the redundant cd sissvoc and cd .. (no point)
+
+#remove the -c from the line below (was not exucuting when run in the linux environment)
+bash package-sissvoc-vanilla--no-build.sh
 


### PR DESCRIPTION
1.  Edit documentation to add Maven to pre-requisites for linux
2.  Edit the script (package-sissvoc-vanilla—no-build.sh) to get rid of:
   a.  Redundant cd sissvoc & cd ..
   b.  The –c from bash –c package-sissvoc-vanilla—no-build.sh
